### PR TITLE
Upgrade prettier to 1.17.1

### DIFF
--- a/prettier/Dockerfile
+++ b/prettier/Dockerfile
@@ -1,7 +1,6 @@
-FROM node:8-alpine
+FROM node:12.3.1-alpine
 MAINTAINER sharils <sharils@users.noreply.github.com>
 
-RUN npm install --global prettier && npm cache --force clean
+RUN npm install --global prettier@1.17.1 && npm cache --force clean
 
-WORKDIR /prettier
 ENTRYPOINT ["prettier"]

--- a/prettier/Dockerfile
+++ b/prettier/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12.3.1-alpine
 MAINTAINER sharils <sharils@users.noreply.github.com>
 
-RUN npm install --global prettier@1.17.1 && npm cache --force clean
+RUN npm install --global prettier@2.0.2 && npm cache --force clean
 
 ENTRYPOINT ["prettier"]


### PR DESCRIPTION
Hi there!

I really liked your Docker images and wanted to contribute.

This is a possible commit to update `prettier` from version 1.9 to version 1.17.1. I decided to enforce the version of prettier in the Dockerfile so that we can reproduce the build, even if prettier was updated in between. I hope you will find it useful!

Best regards,

Marc-Olivier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sharils/dockerfile/5)
<!-- Reviewable:end -->
